### PR TITLE
Fixed NotSupportedException

### DIFF
--- a/src/LogEntry.cs
+++ b/src/LogEntry.cs
@@ -12,6 +12,13 @@ namespace MUnique.Log4Net.CoreSignalR
         /// <summary>
         /// Initializes a new instance of the <see cref="LogEntry"/> class.
         /// </summary>
+        public LogEntry()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LogEntry"/> class.
+        /// </summary>
         /// <param name="id">The unique identifier which is a sequence number.</param>
         /// <param name="formattedEvent">The formtted event as configured in the settings.</param>
         /// <param name="loggingEvent">The logging event data.</param>


### PR DESCRIPTION
The new version of asp.net signalr requires that it has a parameterless constructor. Otherwise we get the following System.NotSupportedException:
"Deserialization of reference types without parameterless constructor is not supported. Type 'MUnique.Log4Net.CoreSignalR.LogEntry'".
So, I added the parameterless constructor in this fix.