### PR TITLE
Fixed that the log level is not transmitted to connected clients

### DIFF
--- a/src/LogLevel.cs
+++ b/src/LogLevel.cs
@@ -40,19 +40,19 @@ namespace MUnique.Log4Net.CoreSignalR
         }
 
         /// <summary>
-        /// Gets the display name of the log level.
+        /// Gets or sets the display name of the log level.
         /// </summary>
-        public string DisplayName { get; }
+        public string DisplayName { get; set; }
 
         /// <summary>
-        /// Gets the name of the log level.
+        /// Gets or sets the name of the log level.
         /// </summary>
-        public string Name { get; }
+        public string Name { get; set; }
 
         /// <summary>
-        /// Gets the numerical value of the log level.
+        /// Gets or sets the numerical value of the log level.
         /// </summary>
-        public int Value { get; }
+        public int Value { get; set; }
 
         /// <summary>
         /// Gets the instance of <see cref="LogLevel"/> of the specified <see cref="Level"/>.

--- a/src/MUnique.Log4Net.CoreSignalR.csproj
+++ b/src/MUnique.Log4Net.CoreSignalR.csproj
@@ -11,8 +11,8 @@
     <PackageTags>log4net signalr dotnetcore netstandard</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>beta5</VersionSuffix>
-    <Version>1.0.0-beta5</Version>
+    <VersionSuffix>beta6</VersionSuffix>
+    <Version>1.0.0-beta6</Version>
     <Company>MUnique</Company>
     <Description>MUnique.Log4Net.CoreSignalR provides a Log4Net Appender which forwards Log4Net log events to a SignalR hub, which is also provided by this package.
 The main use case for MUnique.Log4Net.CoreSignalR is building a log viewer on your website that gives easy visibility to diagnostic information and errors logged on the server.</Description>


### PR DESCRIPTION
Had to add Setters to the properties of the LogLevel class. Otherwise, they might not get (de)serialized by the asp.net core signalr hub and are not filled at the consuming clients.

The caching might only work when sending the messages, though.

Should fix #1.